### PR TITLE
【FIX】修复整数溢出的bug

### DIFF
--- a/src/libs/con_database.py
+++ b/src/libs/con_database.py
@@ -59,6 +59,10 @@ class SQLgo(object):
                 else:
                     data_dict.append({'title': field[0], "key": field[0], "width": 200})
             len = cursor.rowcount
+        for row in result:
+            for k, v in row.items():
+                if isinstance(v, int):
+                    row[k] = str(v)
         return {'data': result, 'title': data_dict, 'len': len}
 
     def dic_data(self, sql=None):


### PR DESCRIPTION

JS 最大整数 9007199254740991，超过会导致自动转化为浮点精度丢失，故在后台转化为 str.