### PR TITLE
修复登录等页面error notice

### DIFF
--- a/webpage/src/components/management/authGroup.vue
+++ b/webpage/src/components/management/authGroup.vue
@@ -342,7 +342,7 @@
             this.pagenumber = parseInt(res.data.page)
           })
           .catch(error => {
-            this.$config.err_notice(this, error)
+            this.$config.err_notice(error)
           })
       },
       splicpage (page) {

--- a/webpage/src/components/management/setting.vue
+++ b/webpage/src/components/management/setting.vue
@@ -331,7 +331,7 @@
             this.$config.notice(res.data)
           })
           .catch(error => {
-            this.$config.err_notice(this, error)
+            this.$config.err_notice(error)
           })
       },
       dingding_test () {
@@ -342,7 +342,7 @@
             this.$config.notice(res.data)
           })
           .catch(error => {
-            this.$config.err_notice(this, error)
+            this.$config.err_notice(error)
           })
       },
       mail_test () {
@@ -367,7 +367,7 @@
             this.$config.notice(res.data)
           })
           .catch(error => {
-            this.$config.err_notice(this, error)
+            this.$config.err_notice(error)
           })
       }
     },

--- a/webpage/src/login.vue
+++ b/webpage/src/login.vue
@@ -237,7 +237,7 @@
             })
           })
           .catch(() => {
-            this.$config.err_notice(this, '账号密码错误,请重新输入!')
+            this.$config.err_notice('账号密码错误,请重新输入!')
           })
       },
       ldap_login () {
@@ -268,7 +268,7 @@
             }
           })
           .catch(() => {
-            this.$config.err_notice(this, '账号密码错误,请重新输入!')
+            this.$config.err_notice('账号密码错误,请重新输入!')
           })
       }
     },


### PR DESCRIPTION
原有代码，重构util.err_notice时，忘记删除this，导致多传递一个参数

![_20190110142539](https://user-images.githubusercontent.com/3257199/50950038-a59a5f00-14e3-11e9-87df-1fe7f188dca2.png)

删除之后，notice显示正常
![_20190110142757](https://user-images.githubusercontent.com/3257199/50950129-f611bc80-14e3-11e9-9935-dea546971966.png)
