### PR TITLE
权限组选择添加搜索功能

### DIFF
--- a/webpage/package.json
+++ b/webpage/package.json
@@ -23,6 +23,7 @@
     "stylus": "^0.54.5",
     "stylus-loader": "^3.0.1",
     "vue": "^2.5.13",
+    "vue-multiselect": "^2.1.6",
     "vue-router": "^2.8.1",
     "vuex": "^2.4.0"
   },

--- a/webpage/src/components/management/userInfo.vue
+++ b/webpage/src/components/management/userInfo.vue
@@ -120,9 +120,15 @@
           <Input v-model="editAuthForm.department" placeholder="请输入新部门"></Input>
         </FormItem>
         <FormItem label="权限组" prop="authgroup">
-          <Select v-model="editAuthForm.authgroup" multiple @on-change="getGroupList" placeholder="请选择">
-            <Option v-for="list in groupset" :value="list" :key="list">{{ list }}</Option>
-          </Select>
+          <multiselect
+            v-model="editAuthForm.authgroup" :options="groupset" :multiple="true"
+            :close-on-select="false" :clear-on-select="false" :preserve-search="true"
+            placeholder="输入搜索" @close="getGroupList"
+          >
+            <template slot="singleLabel" slot-scope="option">
+              {{ option }}
+            </template>
+          </multiselect>
           <template>
             <FormItem>
               <Divider orientation="left">DDL权限</Divider>
@@ -186,9 +192,13 @@
 </template>
 <script>
   import axios from 'axios'
+  import Multiselect from 'vue-multiselect'
   import '../../assets/tablesmargintop.css'
 
   export default {
+    components: {
+      Multiselect
+    },
     data () {
       const valideRePassword = (rule, value, callback) => { // eslint-disable-line no-unused-vars
         if (value !== this.editPasswordForm.newPass) {
@@ -593,3 +603,4 @@
     }
   }
 </script>
+<style src="vue-multiselect/dist/vue-multiselect.min.css"></style>

--- a/webpage/src/components/personalCenter/own-space.vue
+++ b/webpage/src/components/personalCenter/own-space.vue
@@ -71,9 +71,15 @@
       <h3 slot="header" style="color:#2D8CF0">权限申请单</h3>
       <Form :label-width="120" label-position="right">
         <FormItem label="权限组" prop="authgroup">
-          <Select v-model="applygroup" multiple @on-change="getgrouplist" placeholder="请选择">
-            <Option v-for="list in groupset" :value="list" :key="list">{{ list }}</Option>
-          </Select>
+          <multiselect
+            v-model="authgroup" :options="groupset" :multiple="true"
+            :close-on-select="false" :clear-on-select="false" :preserve-search="true"
+            placeholder="输入搜索" @close="getgrouplist"
+          >
+            <template slot="singleLabel" slot-scope="option">
+              {{ option }}
+            </template>
+          </multiselect>
           <template>
             <FormItem>
               <Divider orientation="left">DDL权限</Divider>
@@ -124,9 +130,13 @@
   //
 
   import axios from 'axios'
+  import Multiselect from 'vue-multiselect'
 
   export default {
     name: 'own-space',
+    components: {
+      Multiselect
+    },
     data () {
       const valideRePassword = (rule, value, callback) => {
         if (value !== this.editPasswordForm.newPass) {
@@ -310,3 +320,4 @@
     }
   }
 </script>
+<style src="vue-multiselect/dist/vue-multiselect.min.css"></style>


### PR DESCRIPTION
由于权限组过多时选择权限组时找起来很麻烦，所以使用 vue-multiselect 使得选择权限组时可以搜索。

效果演示：
![image](https://user-images.githubusercontent.com/26321303/58163382-8217ca00-7cb6-11e9-93f5-38dc8cf7ec81.png)
