### PR TITLE
fix go1.13 build

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,5 +22,5 @@ require (
 	gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d // indirect
 	gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df
 	gopkg.in/ldap.v3 v3.0.3
-	vitess.io/vitess v0.0.0-20190119075008-dbef792951a40d6ac55f4d58fe50c7ce8e4fc665
+	vitess.io/vitess v0.0.0-20190119075008-dbef792951a4
 )


### PR DESCRIPTION
```
go: vitess.io/vitess@v0.0.0-20190119075008-dbef792951a40d6ac55f4d58fe50c7ce8e4fc665: reading https://goproxy.cn/vitess.io/vitess/@v/v0.0.0-20190119075008-dbef792951a40d6ac55f4d58fe50c7ce8e4fc665.mod: 404 Not Found
```