### PR TITLE
fix(migrate/autoMigrate): 修复流程某阶段节点审核人过多导致的工单创建失败

### DIFF
--- a/migration/migrate.go
+++ b/migration/migrate.go
@@ -41,10 +41,12 @@ func main() {
 	model.DB().Model(model.CoreQueryOrder{}).DropColumn("id_c")
 	model.DB().Model(model.CoreQueryOrder{}).DropColumn("ex_date")
 	model.DB().LogMode(true).Exec("alter table core_query_records change COLUMN base_name `schema` varchar(50) not null")
+	model.DB().LogMode(true).Exec("alter table core_query_records change COLUMN assigned `assigned` varchar(500) not null")
 	model.DB().Model(model.CoreAccount{}).DropColumn("rule")
 	model.DB().Model(model.CoreSqlOrder{}).DropColumn("percent")
 	model.DB().Model(model.CoreSqlOrder{}).DropColumn("current")
 	model.DB().Model(model.CoreSqlOrder{}).DropColumn("executor")
+	model.DB().LogMode(true).Exec("alter table core_sql_orders change COLUMN assigned `assigned` varchar(500) not null")
 	model.DB().LogMode(true).Exec("alter table core_query_orders change COLUMN realname `real_name` varchar(50) not null")
 	model.DB().AutoMigrate(model.CoreRoleGroup{})
 	var r []model.CoreRoleGroup

--- a/src/model/modal.go
+++ b/src/model/modal.go
@@ -97,7 +97,7 @@ type CoreSqlOrder struct {
 	Date        string `gorm:"type:varchar(50);not null" json:"date"`
 	SQL         string `gorm:"type:longtext;not null" json:"sql"`
 	Text        string `gorm:"type:longtext;not null" json:"text"`
-	Assigned    string `gorm:"type:varchar(50);not null" json:"assigned"`
+	Assigned    string `gorm:"type:varchar(500);not null" json:"assigned"`
 	Delay       string `gorm:"type:varchar(50);not null;default:'none'" json:"delay"`
 	RealName    string `gorm:"type:varchar(50);not null" json:"real_name"`
 	ExecuteTime string `gorm:"type:varchar(50);" json:"execute_time"`
@@ -151,7 +151,7 @@ type CoreQueryOrder struct {
 	Date         string `gorm:"type:varchar(50);not null" json:"date"`
 	ApprovalTime string `gorm:"type:varchar(50);not null" json:"approval_time"`
 	Text         string `gorm:"type:longtext;not null" json:"text"`
-	Assigned     string `gorm:"type:varchar(50);not null" json:"assigned"`
+	Assigned     string `gorm:"type:varchar(500);not null" json:"assigned"`
 	RealName     string `gorm:"type:varchar(50);not null" json:"real_name"`
 	Export       uint   `gorm:"type:tinyint(2);not null" json:"export"`
 	SourceId     string `gorm:"type:varchar(200);not null;index:source_idx"  json:"source_id"`
@@ -193,7 +193,7 @@ type CoreWorkflowDetail struct {
 	WorkId   string `gorm:"type:varchar(50);not null;index:workId_idx" json:"work_id"`
 	Username string `gorm:"type:varchar(50);not null;index:query_idx" json:"username"`
 	Time     string `gorm:"type:varchar(50);not null;" json:"time"`
-	Action   string `gorm:"type:varchar(50);not null;" json:"action"`
+	Action   string `gorm:"type:varchar(600);not null;" json:"action"`
 }
 
 type CoreOrderComment struct {


### PR DESCRIPTION
assgined 字段设置过短导致的工单创建失败

Closes #603