### PR TITLE
fix: 修复 model CoreDataSource DBType字段的类型 , string -> int

### DIFF
--- a/src/model/modal.go
+++ b/src/model/modal.go
@@ -129,7 +129,7 @@ type CoreDataSource struct {
 	CAFile           string `gorm:"type:longtext;default ''" json:"ca_file"`
 	Cert             string `gorm:"type:longtext;default ''" json:"cert"`
 	KeyFile          string `gorm:"type:longtext;default ''" json:"key_file"`
-	DBType           string `gorm:"type:int(5);not null;default 0" json:"db_type"` // 0 mysql 1 pg
+	DBType           int `gorm:"type:int(5);not null;default 0" json:"db_type"` // 0 mysql 1 pg
 	RuleId           int    `gorm:"type:int(100);not null;default 0" json:"rule_id"`
 }
 


### PR DESCRIPTION
文件地址: src/model/modal.go:132

创建数据源前端传入的json中 db_type为 number类型 后端model实体定义的则为string类型, 导致创建数据源报错
```
{
  "db": {
    "idc": "test",
    "source": "test",
    "ip": "127.0.0.1",
    "port": 3306,
    "password": "root",
    "username": "root",
    "is_query": 2,
    "flow_id": 1,
    "principal": "admin",
    "ca_file": "",
    "cert": "",
    "key_file": "",
    "db_type": 0
  },
  "tp": "create"
}
```