### PR TITLE
兼容飞书和企业微信消息通知

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Jeffail/gabs/v2 v2.7.0
 	github.com/cookieY/sqlx v1.3.0
 	github.com/cookieY/yee v0.5.1
+	github.com/crazykun/feishu-bot-markdown v0.0.4
 	github.com/deckarep/golang-set/v2 v2.6.0
 	github.com/go-sql-driver/mysql v1.7.1
 	github.com/golang-jwt/jwt v3.2.2+incompatible

--- a/src/handler/manage/settings/setting.go
+++ b/src/handler/manage/settings/setting.go
@@ -19,8 +19,10 @@ import (
 	"Yearning-go/src/lib"
 	"Yearning-go/src/model"
 	"encoding/json"
-	"github.com/cookieY/yee"
 	"net/http"
+	"strings"
+
+	"github.com/cookieY/yee"
 )
 
 type set struct {
@@ -79,7 +81,13 @@ func SuperTestSetting(c yee.Context) (err error) {
 		go lib.SendMail(u.Message.ToUser, u.Message, lib.TemoplateTestMail)
 		return c.JSON(http.StatusOK, common.SuccessPayLoadToMessage(i18n.DefaultLang.Load(i18n.MAIL_TEST)))
 	case "ding":
-		go lib.SendDingMsg(u.Message, lib.Commontext)
+		if strings.Contains(u.Message.WebHook, "dingtalk") {
+			go lib.SendDingMsg(u.Message, lib.Commontext)
+		} else if strings.Contains(u.Message.WebHook, "weixin") {
+			go lib.SendDingMsg(u.Message, lib.Commontext)
+		} else if strings.Contains(u.Message.WebHook, "feishu") {
+			go lib.SendFeishuMsg(u.Message, lib.TmplTestFeishu)
+		}
 		return c.JSON(http.StatusOK, common.SuccessPayLoadToMessage(i18n.DefaultLang.Load(i18n.WEBHOOK_TEST)))
 	case "ldap":
 		ldap := model.ALdap{Ldap: u.Ldap}

--- a/src/handler/order/audit/impl.go
+++ b/src/handler/order/audit/impl.go
@@ -9,9 +9,10 @@ import (
 	"Yearning-go/src/model"
 	"encoding/json"
 	"fmt"
-	"github.com/cookieY/yee/logger"
 	"strings"
 	"time"
+
+	"github.com/cookieY/yee/logger"
 )
 
 type ExecArgs struct {
@@ -86,6 +87,8 @@ func ExecuteOrder(u *Confirm, user string) common.Resp {
 			Time:     time.Now().Format("2006-01-02 15:04"),
 			Action:   i18n.DefaultLang.Load(i18n.ORDER_EXECUTE_STATE),
 		})
+		// 通知
+		lib.MessagePush(u.WorkId, 1, "")
 		return common.SuccessPayLoadToMessage(i18n.DefaultLang.Load(i18n.ORDER_EXECUTE_STATE))
 	}
 	return common.ERR_RPC

--- a/src/lib/feishu.go
+++ b/src/lib/feishu.go
@@ -1,0 +1,51 @@
+package lib
+
+import (
+	"Yearning-go/src/model"
+	"time"
+
+	bot "github.com/crazykun/feishu-bot-markdown"
+)
+
+var TmplTestFeishu = &FeishuMsg{
+	Title:    "Yearning 测试！",
+	No:       "2024022800000000",
+	Username: "pony",
+	Assigned: "admin",
+	Remark:   "测试",
+	Status:   "<font color='green'>成功</font>",
+	Link:     "http://127.0.0.1:8000/",
+}
+
+type FeishuMsg struct {
+	Title    string          `json:"title"`            // 工单标题
+	No       string          `json:"no"`               // 工单编号
+	Db       string          `json:"db,omitempty"`     // 数据库
+	Username string          `json:"username"`         // 提交人员
+	Assigned string          `json:"assigned"`         // 审核人员
+	Remark   string          `json:"remark,omitempty"` // 工单说明
+	Link     string          `json:"link,omitempty"`   // 链接
+	Status   string          `json:"status"`           // 状态
+	Color    bot.FeishuColor `json:"-"`                // 卡片颜色
+}
+
+// 发送消息
+func SendFeishuMsg(msg model.Message, f *FeishuMsg) error {
+	var textMap = map[string]interface{}{
+		"工单编号": f.No,
+		"数据源":  f.Db,
+		"提交人员": f.Username,
+		"审核人员": f.Assigned,
+		"工单说明": f.Remark,
+		"状态":   f.Status,
+		"时间":   time.Now().Format("2006-01-02 15:04:05"),
+	}
+
+	var textFeishu = &bot.FeishuMsg{
+		Title:       f.Title,
+		Markdown:    textMap,
+		Link:        f.Link,
+		HeaderColor: f.Color,
+	}
+	return bot.SendFeishuMsg(msg.WebHook, textFeishu)
+}

--- a/src/lib/wechat.go
+++ b/src/lib/wechat.go
@@ -1,0 +1,58 @@
+package lib
+
+import (
+	"Yearning-go/src/model"
+	"crypto/tls"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+)
+
+func SendWechatMsg(msg model.Message, sv string) {
+	//请求地址模板
+
+	//创建一个请求
+
+	var mx string
+
+	hook := msg.WebHook
+
+	mx = strings.Replace(sv, `\n \n`, `\n`, -1)
+	mx = strings.Replace(mx, `"text":`, `"content":`, 1)
+	if msg.Key != "" {
+		hook = SignWechat(msg.Key, msg.WebHook)
+	}
+
+	req, err := http.NewRequest("POST", hook, strings.NewReader(mx))
+	if err != nil {
+		log.Println(err.Error())
+		return
+	}
+
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+
+	client := &http.Client{Transport: tr}
+	//设置请求头
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	//发送请求
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Println(err.Error())
+		return
+	}
+
+	//关闭请求
+	resp.Body.Close()
+}
+
+func SignWechat(secret, hook string) string {
+	timestamp := time.Now().UnixNano() / 1e6
+	stringToSign := fmt.Sprintf("%d\n%s", timestamp, secret)
+	sign := hmacSha256(stringToSign, secret)
+	url := fmt.Sprintf("%s&timestamp=%d&sign=%s", hook, timestamp, sign)
+	return url
+}


### PR DESCRIPTION
## 新增功能：兼容飞书和企业微信消息通知

### 描述
本次 PR 添加了新的功能，使得项目可以向飞书和企业微信发送消息通知，原理是根据地址url不同判断不同的通知方式。这个功能的引入将帮助不同工具团队接收消息提醒。

### 主要变动
- 新增支持向飞书发送消息通知的功能
- 新增支持向企业微信发送消息通知的功能

### 截图
![image](https://github.com/cookieY/Yearning/assets/5958797/d95e42d7-218c-4759-a590-a065fa43cb28)

